### PR TITLE
Convert proposal ID to hex format in governance links

### DIFF
--- a/src/notify/event/renderers/default.ts
+++ b/src/notify/event/renderers/default.ts
@@ -59,7 +59,8 @@ export const defaultEventRenderer = registerEventRenderer(
     // Governance link
     let description: string | undefined
     if (data && 'proposalId' in data && log.address === OGN_GOVERNANCE_ADDRESS) {
-      const proposalUrl = `https://originprotocol.eth.limo/#/more/1:${OGN_GOVERNANCE_ADDRESS}:${data.proposalId}`
+      const proposalIdHex = '0x' + BigInt(data.proposalId as string | bigint).toString(16)
+      const proposalUrl = `https://originprotocol.eth.limo/#/more/1:${OGN_GOVERNANCE_ADDRESS}:${proposalIdHex}`
       description = `[View Proposal](${proposalUrl})`
     }
 

--- a/src/notify/event/renderers/default.ts
+++ b/src/notify/event/renderers/default.ts
@@ -59,8 +59,7 @@ export const defaultEventRenderer = registerEventRenderer(
     // Governance link
     let description: string | undefined
     if (data && 'proposalId' in data && log.address === OGN_GOVERNANCE_ADDRESS) {
-      const proposalIdHex = '0x' + BigInt(data.proposalId as string | bigint).toString(16)
-      const proposalUrl = `https://originprotocol.eth.limo/#/more/1:${OGN_GOVERNANCE_ADDRESS}:${proposalIdHex}`
+      const proposalUrl = `https://app.originprotocol.com/#/ogn/governance/1:${OGN_GOVERNANCE_ADDRESS}:${data.proposalId}`
       description = `[View Proposal](${proposalUrl})`
     }
 


### PR DESCRIPTION
## Summary
Updated the governance proposal URL generation to convert the proposal ID to hexadecimal format before constructing the link.

## Key Changes
- Convert `proposalId` from decimal to hexadecimal format using `BigInt` conversion
- Prepend '0x' prefix to the hexadecimal proposal ID
- Use the formatted hex ID in the governance proposal URL instead of the raw decimal value

## Implementation Details
The proposal ID is now converted using `BigInt(data.proposalId as string | bigint).toString(16)` to handle both string and bigint input types, then prefixed with '0x' to create a proper hexadecimal representation. This ensures the governance link uses the correct format expected by the Origin Protocol governance interface.

https://claude.ai/code/session_01ErhGfwD5hTV6BiFXpsSwKD